### PR TITLE
Update docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
   build:
     docker:
       # specify the version you desire here
-      - image: cimg/openjdk:8.0-node
+      - image: cimg/openjdk:8.0.292-node
 
     working_directory: ~/tmp
 


### PR DESCRIPTION
Moving from image: cimg/openjdk:8.0-node to image: cimg/openjdk:8.0.292-node for better support and performance