### PR TITLE
daily CircleCI job - test plan update

### DIFF
--- a/xray-conf/createTestExecution.json
+++ b/xray-conf/createTestExecution.json
@@ -16,6 +16,6 @@
         ]
     },
     "xrayFields": {
-        "testPlanKey": "CORE-3589"
+        "testPlanKey": "CORE-888"
       }
 }


### PR DESCRIPTION
Current test plan points to a a test plan for a specific version of the node (https://rsklabs.atlassian.net/browse/CORE-3589). Since it's a daily job, it should be pointing (always) to a default test plan where to track the daily executions: https://rsklabs.atlassian.net/browse/CORE-888

On demand jobs to cover specific node version, should change the test plan id in a separate branch (not merged to master)
